### PR TITLE
Feature/custom client

### DIFF
--- a/deploy/packaging/glaukos_spruce.yaml
+++ b/deploy/packaging/glaukos_spruce.yaml
@@ -194,6 +194,7 @@ webhook:
     buffer: "5s"
 codex:
   address: (( grab $CODEX_ADDRESS || "localhost:6000" ))
+  maxRetryCount: (( grab $CODEX_MAX_RETRY_COUNT || 0 ))
   auth:
     # basic provides a way to use Basic Authorization when registering to a
     # webhook.  If this value is provided and sat isn't, the following header is

--- a/event/parsing/codexClient_test.go
+++ b/event/parsing/codexClient_test.go
@@ -4,31 +4,100 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/bascule/acquire"
 )
 
-func TestBuildRequest(t *testing.T) {
+func TestBuildGetRequest(t *testing.T) {
 	assert := assert.New(t)
+	fixedAuth, _ := acquire.NewFixedAuthAcquirer("test")
 	tests := []struct {
 		description string
 		address     string
-		auth        string
+		auth        acquire.Acquirer
+		errExpected bool
 	}{
 		{
 			description: "Success",
 			address:     "http://foo.com/test",
-			auth:        "test",
+			auth:        fixedAuth,
+		},
+		{
+			description: "Nil Auth",
+			address:     "http://foo.com/test",
+			auth:        nil,
+			errExpected: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			auth, _ := acquire.NewFixedAuthAcquirer(tc.auth)
-			req, err := buildRequest(tc.address, auth)
-			assert.Equal(http.MethodGet, req.Method)
-			assert.Equal(tc.auth, req.Header.Get("Authorization"))
-			assert.Nil(err)
+			req, err := buildGetRequest(tc.address, tc.auth)
+
+			if tc.errExpected {
+				assert.Nil(req)
+				assert.NotNil(err)
+			} else {
+				assert.Equal(http.MethodGet, req.Method)
+				assert.NotEmpty(req.Header.Get("Authorization"))
+				assert.Nil(err)
+			}
+
 		})
 	}
+}
+
+func TestDoRequest(t *testing.T) {
+	var (
+		assert = assert.New(t)
+		c      = CodexClient{
+			logger: log.NewNopLogger(),
+			client: http.DefaultClient,
+		}
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	code, data, err := c.doRequest(req)
+	assert.Equal(0, code)
+	assert.Equal(0, len(data))
+	assert.NotNil(err)
+}
+
+func TestGetEvents(t *testing.T) {
+	assert := assert.New(t)
+	auth, _ := acquire.NewFixedAuthAcquirer("test")
+
+	tests := []struct {
+		description string
+		address     string
+		auth        acquire.Acquirer
+		errExpected bool
+	}{
+		{
+			description: "Problem building request",
+			address:     "test",
+			auth:        nil,
+		},
+		{
+			description: "Invalid URL",
+			address:     "test",
+			auth:        auth,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			c := CodexClient{
+				logger:  log.NewNopLogger(),
+				client:  http.DefaultClient,
+				Address: tc.address,
+				Auth:    auth,
+			}
+
+			events := c.GetEvents("test-device")
+			assert.Empty(events)
+		})
+	}
+
 }

--- a/event/parsing/provide.go
+++ b/event/parsing/provide.go
@@ -1,7 +1,6 @@
 package parsing
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -53,8 +52,6 @@ func Provide() fx.Option {
 					ShouldRetry:       func(error) bool { return true },
 					ShouldRetryStatus: func(code int) bool { return false },
 				}
-
-				fmt.Println(retryOptions.Retries)
 
 				return &CodexClient{
 					Address:      config.Address,

--- a/glaukos.yaml
+++ b/glaukos.yaml
@@ -160,6 +160,8 @@ webhook:
 
 codex:
   address: localhost:7000
+  # maxRetryCount is the max number of retries when making the request to codex.
+  maxRetryCount: 0
   auth:
     # basic provides a way to use Basic Authorization when registering to a
     # webhook.  If this value is provided and sat isn't, the following header is


### PR DESCRIPTION
Change `CodexClient` to save custom `*http.Client` in case user wants to override default client behavior

Closes #14 