### PR TITLE
Fix boot-time calculation bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Change boot-time calculation to use the time that the request is received, remove absolute value in boot-time calculation. [#31](https://github.com/xmidt-org/glaukos/pull/31)
 
 ## [v0.1.1]
 - Nothing has changed.

--- a/event/endpoints.go
+++ b/event/endpoints.go
@@ -7,6 +7,7 @@ package event
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/xmidt-org/glaukos/event/queue"
 	"github.com/xmidt-org/themis/xlog"
@@ -42,12 +43,13 @@ type EndpointsDecodeIn struct {
 func NewEndpoints(eventQueue *queue.EventQueue, logger log.Logger) Endpoints {
 	return Endpoints{
 		Event: func(_ context.Context, request interface{}) (interface{}, error) {
+			begin := time.Now()
 			v, ok := request.(wrp.Message)
 			if !ok {
 				return nil, errors.New("invalid request info")
 			}
 
-			if err := eventQueue.Queue(v); err != nil {
+			if err := eventQueue.Queue(queue.WrpWithTime{Message: v, Beginning: begin}); err != nil {
 				level.Error(logger).Log(xlog.ErrorKey(), err, xlog.MessageKey(), "failed to queue message")
 				return nil, err
 			}

--- a/event/parsing/bootTimeParser.go
+++ b/event/parsing/bootTimeParser.go
@@ -6,12 +6,12 @@ package parsing
 
 import (
 	"errors"
-	"math"
 	"regexp"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/xmidt-org/glaukos/event/queue"
 	"github.com/xmidt-org/themis/xlog"
 	"github.com/xmidt-org/wrp-go/v3"
 )
@@ -26,9 +26,10 @@ const (
 )
 
 var (
-	errNewerBootTime = errors.New("found newer boot-time")
-	errSameBootTime  = errors.New("found same boot-time")
-	errRestartTime   = errors.New("failed to get restart time")
+	errNewerBootTime      = errors.New("found newer boot-time")
+	errSameBootTime       = errors.New("found same boot-time")
+	errRestartTime        = errors.New("failed to get restart time")
+	errInvalidRestartTime = errors.New("invalid restart time")
 )
 
 type EventClient interface {
@@ -55,16 +56,17 @@ Steps to calculate boot time:
 	3) Subtract Online birthdate from steps 2 event Birthdate.
 	4) Record Metric.
 */
-func (b BootTimeParser) Parse(msg wrp.Message) error {
+func (b BootTimeParser) Parse(wrpWithTime queue.WrpWithTime) error {
 	// Add to metrics if no error calculating restart time.
-	if restartTime, err := b.calculateRestartTime(msg); err == nil && restartTime > 0 {
-		b.Measures.BootTimeHistogram.With(HardwareLabel, msg.Metadata[hardwareKey], FirmwareLabel, msg.Metadata[firmwareKey]).Observe(restartTime)
+	if restartTime, err := b.calculateRestartTime(wrpWithTime); err == nil && restartTime > 0 {
+		b.Measures.BootTimeHistogram.With(HardwareLabel, wrpWithTime.Message.Metadata[hardwareKey], FirmwareLabel, wrpWithTime.Message.Metadata[firmwareKey]).Observe(restartTime)
 	}
 
 	return nil
 }
 
-func (b *BootTimeParser) calculateRestartTime(msg wrp.Message) (float64, error) {
+func (b *BootTimeParser) calculateRestartTime(wrpWithTime queue.WrpWithTime) (float64, error) {
+	msg := wrpWithTime.Message
 	// If event is not an online event, do not continue with calculations.
 	if !destinationRegex.MatchString(msg.Destination) || !onlineRegex.MatchString(msg.Destination) {
 		level.Debug(b.Logger).Log(xlog.MessageKey(), "event is not an online event")
@@ -78,7 +80,6 @@ func (b *BootTimeParser) calculateRestartTime(msg wrp.Message) (float64, error) 
 		return -1, err
 	}
 
-	latestBootTime := time.Unix(bootTimeInt, 0)
 	previousBootTime := int64(0)
 
 	// Get events from codex pertaining to this device id.
@@ -107,7 +108,13 @@ func (b *BootTimeParser) calculateRestartTime(msg wrp.Message) (float64, error) 
 
 	// boot time calculation
 	// Event birthdate is saved in unix nanoseconds, so we must first convert it to a unix time using nanoseconds.
-	restartTime := math.Abs(latestBootTime.Sub(time.Unix(0, latestOfflineEvent)).Seconds())
+	restartTime := wrpWithTime.Beginning.Sub(time.Unix(0, latestOfflineEvent)).Seconds()
+
+	if restartTime <= 0 {
+		err = errInvalidRestartTime
+		level.Error(b.Logger).Log(xlog.ErrorKey(), err, "Restart time", restartTime)
+		return -1, err
+	}
 	// Add to metrics or log the error.
 	if latestOfflineEvent != 0 && previousBootTime != 0 {
 		return restartTime, nil
@@ -137,6 +144,9 @@ func checkOnlineEvent(e Event, currentUUID string, previousBootTime int64, lates
 	if eventBootTimeInt > latestBootTime {
 		return -1, errNewerBootTime
 	}
+
+	// if another online event is found with the same boot time but different transaction uuid, it means the event
+	// received is not the result of a true restart
 	if eventBootTimeInt == latestBootTime && e.TransactionUUID != currentUUID {
 		return -1, errSameBootTime
 	}

--- a/event/parsing/bootTimeParser_test.go
+++ b/event/parsing/bootTimeParser_test.go
@@ -349,11 +349,19 @@ func TestCalculateRestartTimeError(t *testing.T) {
 				Event{
 					MsgType:         4,
 					Dest:            "event:device-status/mac:112233445566/online",
-					TransactionUUID: "testOnline",
+					TransactionUUID: "testOnline2",
 					Metadata: map[string]string{
 						bootTimeKey: fmt.Sprint(now.Add(-5 * time.Minute).Unix()),
 					},
-					BirthDate: now.Add(-5 * time.Second).UnixNano(),
+				},
+				Event{
+					MsgType:         4,
+					Dest:            "event:device-status/mac:112233445566/offline",
+					TransactionUUID: "testOffline2",
+					Metadata: map[string]string{
+						bootTimeKey: fmt.Sprint(now.Add(-5 * time.Minute).Unix()),
+					},
+					BirthDate: now.Add(-1 * time.Second).UnixNano(),
 				},
 			},
 		},
@@ -371,11 +379,19 @@ func TestCalculateRestartTimeError(t *testing.T) {
 				Event{
 					MsgType:         4,
 					Dest:            "event:device-status/mac:112233445566/online",
-					TransactionUUID: "testOnline",
+					TransactionUUID: "testOnline2",
 					Metadata: map[string]string{
 						bootTimeKey: fmt.Sprint(now.Add(-5 * time.Minute).Unix()),
 					},
-					BirthDate: now.Add(-5 * time.Second).UnixNano(),
+				},
+				Event{
+					MsgType:         4,
+					Dest:            "event:device-status/mac:112233445566/offline",
+					TransactionUUID: "testOffline2",
+					Metadata: map[string]string{
+						bootTimeKey: fmt.Sprint(now.Add(-5 * time.Minute).Unix()),
+					},
+					BirthDate: now.UnixNano(),
 				},
 			},
 		},

--- a/event/parsing/metadataParser.go
+++ b/event/parsing/metadataParser.go
@@ -3,7 +3,7 @@ package parsing
 import (
 	"errors"
 
-	"github.com/xmidt-org/wrp-go/v3"
+	"github.com/xmidt-org/glaukos/event/queue"
 )
 
 const (
@@ -19,12 +19,12 @@ type MetadataParser struct {
 }
 
 // Parse gathers metrics for each metadata key.
-func (m MetadataParser) Parse(msg wrp.Message) error {
-	if len(msg.Metadata) < 1 {
+func (m MetadataParser) Parse(wrpWithTime queue.WrpWithTime) error {
+	if len(wrpWithTime.Message.Metadata) < 1 {
 		m.Measures.UnparsableEventsCount.With(ParserLabel, metadataParserLabel, ReasonLabel, noMetadataFoundErr).Add(1.0)
 		return errors.New("no metadata found")
 	}
-	for key := range msg.Metadata {
+	for key := range wrpWithTime.Message.Metadata {
 		m.Measures.MetadataFields.With(MetadataKeyLabel, key).Add(1.0)
 	}
 	return nil

--- a/event/parsing/metadataParser_test.go
+++ b/event/parsing/metadataParser_test.go
@@ -2,7 +2,9 @@ package parsing
 
 import (
 	"testing"
+	"time"
 
+	"github.com/xmidt-org/glaukos/event/queue"
 	"github.com/xmidt-org/webpa-common/xmetrics"
 	"github.com/xmidt-org/webpa-common/xmetrics/xmetricstest"
 	"github.com/xmidt-org/wrp-go/v3"
@@ -60,7 +62,7 @@ func TestParse(t *testing.T) {
 				Measures: m,
 			}
 
-			mp.Parse(tc.message)
+			mp.Parse(queue.WrpWithTime{Message: tc.message, Beginning: time.Now()})
 			for key, val := range tc.expectedCount {
 				p.Assert(t, "metadata_keys", MetadataKeyLabel, key)(xmetricstest.Value(val))
 			}
@@ -116,7 +118,7 @@ func TestMultipleParse(t *testing.T) {
 	}
 
 	for _, msg := range messages {
-		mp.Parse(msg)
+		mp.Parse(queue.WrpWithTime{Message: msg, Beginning: time.Now()})
 	}
 
 	p.Assert(t, "metadata_keys", MetadataKeyLabel, trustKey)(xmetricstest.Value(3.0))

--- a/event/parsing/wrpParsers.go
+++ b/event/parsing/wrpParsers.go
@@ -1,15 +1,20 @@
 package parsing
 
 import (
+	"encoding/json"
 	"errors"
 	"regexp"
 	"strconv"
+	"time"
 
+	"github.com/goph/emperror"
 	"github.com/xmidt-org/wrp-go/v3"
 )
 
 var (
-	errParseDeviceID = errors.New("error getting device ID from event")
+	errParseDeviceID   = errors.New("error getting device ID from event")
+	errFutureBirthDate = errors.New("birthdate is too far in the future")
+	errPastBirthDate   = errors.New("birthdate is too far in the past")
 )
 
 // GetWRPBootTime grabs the boot-time from a wrp.Message's metadata.
@@ -46,4 +51,50 @@ func GetDeviceID(destinationRegex *regexp.Regexp, destination string) (string, e
 	}
 
 	return match[2], nil
+}
+
+// GetValidBirthDate attempts to get the birthdate from the payload.
+// If it doesn't exist, the current time is returned.
+// If the birthdate is too old or too far in the future, 0 is returned.
+func GetValidBirthDate(currTime func() time.Time, payload []byte) (time.Time, error) {
+	now := currTime()
+	birthDate, ok := getBirthDate(payload)
+	if !ok {
+		birthDate = now
+	}
+
+	// for time skew reasons
+	if birthDate.After(now.Add(time.Hour)) {
+		return time.Time{}, emperror.WrapWith(errFutureBirthDate, "invalid birthdate", "birthdate", birthDate.String())
+	}
+
+	// check if birth date is too old (past a week)
+	// TODO: should this be configurable?
+	if birthDate.Before(now.Add(-168 * time.Hour)) {
+		return time.Time{}, emperror.WrapWith(errPastBirthDate, "invalid birthdate", "birthdate", birthDate.String())
+	}
+
+	return birthDate, nil
+}
+
+func getBirthDate(payload []byte) (time.Time, bool) {
+	p := make(map[string]interface{})
+	if len(payload) == 0 {
+		return time.Time{}, false
+	}
+	err := json.Unmarshal(payload, &p)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	// parse the time from the payload
+	timeString, ok := p["ts"].(string)
+	if !ok {
+		return time.Time{}, false
+	}
+	birthDate, err := time.Parse(time.RFC3339Nano, timeString)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return birthDate, true
 }

--- a/event/parsing/wrpParsers_test.go
+++ b/event/parsing/wrpParsers_test.go
@@ -192,7 +192,7 @@ func TestGetValidBirthDate(t *testing.T) {
 			expectedErr: errFutureBirthDate,
 		},
 		{
-			description: "Future Birthdate Error",
+			description: "Past Birthdate Error",
 			fakeNow:     currTime.Add(200 * time.Hour),
 			payload:     payload,
 			expectedErr: errPastBirthDate,
@@ -206,7 +206,7 @@ func TestGetValidBirthDate(t *testing.T) {
 				return tc.fakeNow
 			}
 			b, err := GetValidBirthDate(currTime, tc.payload)
-			assert.Equal(tc.expectedBirthDate, b, "birth date mismatch")
+			assert.Equal(tc.expectedBirthDate, b)
 			if tc.expectedErr == nil || err == nil {
 				assert.Equal(tc.expectedErr, err)
 			} else {

--- a/event/parsing/wrpParsers_test.go
+++ b/event/parsing/wrpParsers_test.go
@@ -3,6 +3,7 @@ package parsing
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/wrp-go/v3"
@@ -153,6 +154,106 @@ func TestGetDeviceID(t *testing.T) {
 				assert.True(errors.Is(err, tc.expectedErr))
 			}
 
+		})
+	}
+}
+
+func TestGetValidBirthDate(t *testing.T) {
+	payload := []byte(`{"ts":"2019-02-13T21:19:02.614191735Z"}`)
+	testassert := assert.New(t)
+	goodTime, err := time.Parse(time.RFC3339Nano, "2019-02-13T21:19:02.614191735Z")
+	testassert.Nil(err)
+	currTime, err := time.Parse(time.RFC3339Nano, "2019-02-13T21:21:21.614191735Z")
+	testassert.Nil(err)
+
+	tests := []struct {
+		description       string
+		fakeNow           time.Time
+		payload           []byte
+		expectedBirthDate time.Time
+		expectedErr       error
+	}{
+		{
+			description:       "Success",
+			fakeNow:           currTime,
+			payload:           payload,
+			expectedBirthDate: goodTime,
+		},
+		{
+			description:       "Success No Birthdate in Payload",
+			fakeNow:           currTime,
+			payload:           nil,
+			expectedBirthDate: currTime,
+		},
+		{
+			description: "Future Birthdate Error",
+			fakeNow:     currTime.Add(-5 * time.Hour),
+			payload:     payload,
+			expectedErr: errFutureBirthDate,
+		},
+		{
+			description: "Future Birthdate Error",
+			fakeNow:     currTime.Add(200 * time.Hour),
+			payload:     payload,
+			expectedErr: errPastBirthDate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			currTime := func() time.Time {
+				return tc.fakeNow
+			}
+			b, err := GetValidBirthDate(currTime, tc.payload)
+			assert.Equal(tc.expectedBirthDate, b, "birth date mismatch")
+			if tc.expectedErr == nil || err == nil {
+				assert.Equal(tc.expectedErr, err)
+			} else {
+				assert.Contains(err.Error(), tc.expectedErr.Error())
+			}
+		})
+	}
+}
+
+func TestGetBirthDate(t *testing.T) {
+	goodTime, err := time.Parse(time.RFC3339Nano, "2019-02-13T21:19:02.614191735Z")
+	assert.Nil(t, err)
+	tests := []struct {
+		description   string
+		payload       []byte
+		expectedTime  time.Time
+		expectedFound bool
+	}{
+		{
+			description:   "Success",
+			payload:       []byte(`{"ts":"2019-02-13T21:19:02.614191735Z"}`),
+			expectedTime:  goodTime,
+			expectedFound: true,
+		},
+		{
+			description: "Unmarshal Payload Error",
+			payload:     []byte("test"),
+		},
+		{
+			description: "Empty Payload String Error",
+			payload:     []byte(``),
+		},
+		{
+			description: "Non-String Timestamp Error",
+			payload:     []byte(`{"ts":5}`),
+		},
+		{
+			description: "Parse Timestamp Error",
+			payload:     []byte(`{"ts":"2345"}`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			time, found := getBirthDate(tc.payload)
+			assert.Equal(time, tc.expectedTime)
+			assert.Equal(found, tc.expectedFound)
 		})
 	}
 }

--- a/event/queue/mocks.go
+++ b/event/queue/mocks.go
@@ -2,14 +2,13 @@ package queue
 
 import (
 	"github.com/stretchr/testify/mock"
-	"github.com/xmidt-org/wrp-go/v3"
 )
 
 type MockParser struct {
 	mock.Mock
 }
 
-func (mp *MockParser) Parse(msg wrp.Message) error {
-	args := mp.Called(msg)
+func (mp *MockParser) Parse(wrpWithTime WrpWithTime) error {
+	args := mp.Called(wrpWithTime)
 	return args.Error(0)
 }


### PR DESCRIPTION
* Instead of using an event's boot-time to calculate the restart time, use the timestamp of when glaukos received the request.
* Remove absolute value in restart time calculations and log an error if the restart time is <= 0.

Fixes #26, Fixes #27 