### PR TITLE
Metadata key fix

### DIFF
--- a/event/parsing/wrpParsers.go
+++ b/event/parsing/wrpParsers.go
@@ -17,7 +17,8 @@ var (
 	errFutureDate    = errors.New("date is too far in the future")
 	errPastDate      = errors.New("date is too far in the past")
 
-	errBootTimeParse = errors.New("unable to parse boot-time")
+	errBootTimeParse    = errors.New("unable to parse boot-time")
+	errBootTimeNotFound = errors.New("boot-time not found")
 )
 
 // GetWRPBootTime grabs the boot-time from a wrp.Message's metadata.
@@ -34,9 +35,11 @@ func GetWRPBootTime(msg wrp.Message) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("%w: %v", errBootTimeParse, err)
 		}
+	} else {
+		err = errBootTimeNotFound
 	}
 
-	return bootTime, nil
+	return bootTime, err
 }
 
 // GetEventBootTime grabs the boot-time from a Event's metadata.
@@ -52,8 +55,11 @@ func GetEventBootTime(msg Event) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("%w: %v", errBootTimeParse, err)
 		}
+	} else {
+		err = errBootTimeNotFound
 	}
-	return bootTime, nil
+
+	return bootTime, err
 }
 
 // GetDeviceID grabs the device id from a given destination string.

--- a/event/parsing/wrpParsers.go
+++ b/event/parsing/wrpParsers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/xmidt-org/wrp-go/v3"
@@ -23,12 +24,18 @@ var (
 func GetWRPBootTime(msg wrp.Message) (int64, error) {
 	var bootTime int64
 	var err error
-	if bootTimeStr, ok := msg.Metadata[bootTimeKey]; ok {
+
+	bootTimeStr, ok := msg.Metadata[bootTimeKey]
+	if !ok {
+		bootTimeStr, ok = msg.Metadata[strings.Trim(bootTimeKey, "/\\")]
+	}
+	if ok {
 		bootTime, err = strconv.ParseInt(bootTimeStr, 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("%w: %v", errBootTimeParse, err)
 		}
 	}
+
 	return bootTime, nil
 }
 
@@ -36,7 +43,11 @@ func GetWRPBootTime(msg wrp.Message) (int64, error) {
 func GetEventBootTime(msg Event) (int64, error) {
 	var bootTime int64
 	var err error
-	if bootTimeStr, ok := msg.Metadata[bootTimeKey]; ok {
+	bootTimeStr, ok := msg.Metadata[bootTimeKey]
+	if !ok {
+		bootTimeStr, ok = msg.Metadata[strings.Trim(bootTimeKey, "/")]
+	}
+	if ok {
 		bootTime, err = strconv.ParseInt(bootTimeStr, 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("%w: %v", errBootTimeParse, err)

--- a/event/parsing/wrpParsers.go
+++ b/event/parsing/wrpParsers.go
@@ -27,7 +27,7 @@ func GetWRPBootTime(msg wrp.Message) (int64, error) {
 
 	bootTimeStr, ok := msg.Metadata[bootTimeKey]
 	if !ok {
-		bootTimeStr, ok = msg.Metadata[strings.Trim(bootTimeKey, "/\\")]
+		bootTimeStr, ok = msg.Metadata[strings.Trim(bootTimeKey, "/")]
 	}
 	if ok {
 		bootTime, err = strconv.ParseInt(bootTimeStr, 10, 64)

--- a/event/parsing/wrpParsers_test.go
+++ b/event/parsing/wrpParsers_test.go
@@ -2,6 +2,7 @@ package parsing
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ func TestGetWRPBootTime(t *testing.T) {
 		description      string
 		msg              wrp.Message
 		expectedBootTime int64
-		expectedErr      bool
+		expectedErr      error
 	}{
 		{
 			description: "Success",
@@ -33,6 +34,13 @@ func TestGetWRPBootTime(t *testing.T) {
 				Metadata: map[string]string{},
 			},
 			expectedBootTime: 0,
+			expectedErr:      errBootTimeNotFound,
+		},
+		{
+			description:      "No Metadata",
+			msg:              wrp.Message{},
+			expectedBootTime: 0,
+			expectedErr:      errBootTimeNotFound,
 		},
 		{
 			description: "Key with slash",
@@ -60,7 +68,7 @@ func TestGetWRPBootTime(t *testing.T) {
 				},
 			},
 			expectedBootTime: 0,
-			expectedErr:      true,
+			expectedErr:      errBootTimeParse,
 		},
 	}
 
@@ -69,10 +77,13 @@ func TestGetWRPBootTime(t *testing.T) {
 			time, err := GetWRPBootTime(tc.msg)
 			assert.Equal(tc.expectedBootTime, time)
 
-			if tc.expectedErr {
-				assert.NotNil(err)
+			if tc.expectedErr == nil || err == nil {
+				assert.Equal(tc.expectedErr, err)
 			} else {
-				assert.Nil(err)
+				assert.True(errors.Is(err, tc.expectedErr),
+					fmt.Errorf("error [%v] doesn't contain error [%v] in its err chain",
+						err, tc.expectedErr),
+				)
 			}
 		})
 	}
@@ -85,7 +96,7 @@ func TestGetEventBootTime(t *testing.T) {
 		description      string
 		msg              Event
 		expectedBootTime int64
-		expectedErr      bool
+		expectedErr      error
 	}{
 		{
 			description: "Success",
@@ -102,11 +113,13 @@ func TestGetEventBootTime(t *testing.T) {
 				Metadata: map[string]string{},
 			},
 			expectedBootTime: 0,
+			expectedErr:      errBootTimeNotFound,
 		},
 		{
 			description:      "No Metadata",
 			msg:              Event{},
 			expectedBootTime: 0,
+			expectedErr:      errBootTimeNotFound,
 		},
 		{
 			description: "Key with slash",
@@ -134,7 +147,7 @@ func TestGetEventBootTime(t *testing.T) {
 				},
 			},
 			expectedBootTime: 0,
-			expectedErr:      true,
+			expectedErr:      errBootTimeParse,
 		},
 	}
 
@@ -143,10 +156,13 @@ func TestGetEventBootTime(t *testing.T) {
 			time, err := GetEventBootTime(tc.msg)
 			assert.Equal(tc.expectedBootTime, time)
 
-			if tc.expectedErr {
-				assert.NotNil(err)
+			if tc.expectedErr == nil || err == nil {
+				assert.Equal(tc.expectedErr, err)
 			} else {
-				assert.Nil(err)
+				assert.True(errors.Is(err, tc.expectedErr),
+					fmt.Errorf("error [%v] doesn't contain error [%v] in its err chain",
+						err, tc.expectedErr),
+				)
 			}
 		})
 	}

--- a/event/parsing/wrpParsers_test.go
+++ b/event/parsing/wrpParsers_test.go
@@ -35,6 +35,24 @@ func TestGetWRPBootTime(t *testing.T) {
 			expectedBootTime: 0,
 		},
 		{
+			description: "Key with slash",
+			msg: wrp.Message{
+				Metadata: map[string]string{
+					"/boot-time": "1000",
+				},
+			},
+			expectedBootTime: 1000,
+		},
+		{
+			description: "Key without slash",
+			msg: wrp.Message{
+				Metadata: map[string]string{
+					"boot-time": "1000",
+				},
+			},
+			expectedBootTime: 1000,
+		},
+		{
 			description: "Int conversion error",
 			msg: wrp.Message{
 				Metadata: map[string]string{
@@ -89,6 +107,24 @@ func TestGetEventBootTime(t *testing.T) {
 			description:      "No Metadata",
 			msg:              Event{},
 			expectedBootTime: 0,
+		},
+		{
+			description: "Key with slash",
+			msg: Event{
+				Metadata: map[string]string{
+					"/boot-time": "1000",
+				},
+			},
+			expectedBootTime: 1000,
+		},
+		{
+			description: "Key without slash",
+			msg: Event{
+				Metadata: map[string]string{
+					"boot-time": "1000",
+				},
+			},
+			expectedBootTime: 1000,
 		},
 		{
 			description: "Int conversion error",


### PR DESCRIPTION
Allows for `/boot-time` and `boot-time` as metadata keys.